### PR TITLE
Fix build on (64bit) macOS

### DIFF
--- a/lout/CMakeLists.txt
+++ b/lout/CMakeLists.txt
@@ -12,7 +12,10 @@ if (IS_WINDOWS)
 	include_directories("C:/Boost/include/boost-1_61")
 else ()
 	# Build with all warnings
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -pthread")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
+	if (NOT IS_OSX)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+	endif ()
 	# Setup path for boost headers
 	if (${MINGW})
 		include_directories("C:/Boost/include/boost-1_61")

--- a/lout/dist/include/lout/LoutLogger.h
+++ b/lout/dist/include/lout/LoutLogger.h
@@ -49,7 +49,7 @@ public:
 
 	LoutLogger& operator<<(uint64_t value);
 
-#if ULONG_MAX == (0xFFFFFFFFUL)
+#if ULONG_MAX == (0xFFFFFFFFUL) || __APPLE__
 	// Don't compile this on 64 bit platforms since it is the same as uint64_t
 	LoutLogger& operator<<(unsigned long value);
 #endif

--- a/lout/src/LoutLogger.cpp
+++ b/lout/src/LoutLogger.cpp
@@ -127,7 +127,7 @@ LoutLogger& LoutLogger::operator<<(uint64_t value)
 //
 //
 //////////////////////////////////////////////////////////////////////////
-#if ULONG_MAX == (0xFFFFFFFFUL)
+#if ULONG_MAX == (0xFFFFFFFFUL) || __APPLE__
 // Don't compile this on 64 bit platforms since it is the same as uint64_t
 LoutLogger& LoutLogger::operator<<(unsigned long value)
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,10 @@ if( IS_WINDOWS )
 	link_directories("C:/Boost/lib")
 else()
 	# Build with all warnings
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -pthread")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
+	if (NOT IS_OSX)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+	endif ()
 	# Setup path for boost libs
 	if (${MINGW})
 		link_directories("c:/Boost/lib/")


### PR DESCRIPTION
On 64-bit macOS uint64_t is same as unsigned long long so operator<<(unsigned long) is needed.