### PR TITLE
Fix build warnings on Apple LLVM version 10.0.0 (clang-1000.11.45.5)

### DIFF
--- a/lout/dist/include/lout/LevelItem.h
+++ b/lout/dist/include/lout/LevelItem.h
@@ -14,7 +14,7 @@ namespace lout {
 class LevelItem : public lout::item::ILogItem
 {
 public:
-	LevelItem(const loglevel::ILogLevel& level) : myLevel(level)
+	explicit LevelItem(const loglevel::ILogLevel& level) : myLevel(level)
 	{ }
 
 	void Log(lout::LoutLogger& l) override;

--- a/lout/dist/include/lout/formatting/IFormatter.h
+++ b/lout/dist/include/lout/formatting/IFormatter.h
@@ -10,6 +10,7 @@ namespace lout {
 namespace formatting {
 	class IFormatter {
 	public:
+		virtual ~IFormatter() = default;
 		virtual std::string Format( const time_t& timestamp, const loglevel::ILogLevel &level, const std::string &category, const std::string &msg) = 0;
 		virtual std::string Format( const time_t& timestamp, const loglevel::ILogLevel &level, const std::string &msg) = 0;
 	};

--- a/lout/dist/include/lout/item/ILogItem.h
+++ b/lout/dist/include/lout/item/ILogItem.h
@@ -14,6 +14,7 @@ namespace item {
 class ILogItem
 {
 public:
+	virtual ~ILogItem() = default;
 	virtual void Log( lout::LoutLogger& l ) = 0;
 };
 

--- a/lout/dist/include/lout/threading/ILock.h
+++ b/lout/dist/include/lout/threading/ILock.h
@@ -12,6 +12,8 @@ namespace threading {
 class ILock
 {
 public:
+	virtual ~ILock() = default;
+
 	virtual void Acquire() = 0;
 
 	virtual void Release() = 0;


### PR DESCRIPTION
Some interfaces have no virtual destructors, generates warnings on macOS Mojave.